### PR TITLE
Updates portfolio link URL formatting

### DIFF
--- a/src/components/editor/EditorHeaders.jsx
+++ b/src/components/editor/EditorHeaders.jsx
@@ -288,7 +288,7 @@ function EditorHeaders({
             message: "Your portfolio has been published successfully!",
             imageUrl: "/favicon_io/android-chrome-192x192.png",
             linkText: "View Portfolio",
-            linkUrl: publishedPortfolioUrl+'/'+websiteName,
+            linkUrl: `https://${websiteName}.runit.in`,
             duration: 5000,
             }));
         } else {


### PR DESCRIPTION
Changes the portfolio link generation to use a subdomain-based format (`https://{websiteName}.runit.in`) instead of appending `websiteName` to the published portfolio URL. This improves URL clarity and aligns with standardized subdomain conventions.